### PR TITLE
Add leveled logging and remove stale data check

### DIFF
--- a/battery.go
+++ b/battery.go
@@ -38,10 +38,10 @@ func (b *Battery) Update(idx uint, data BatteryState) {
     b.mu.Lock()
     defer b.mu.Unlock()
 
-    b.log.Printf("DETAILED: Updating battery %d with state: active=%v, temperature_state=%v", idx, data.Active, data.TemperatureState)
+    b.log.Debug("Updating battery %d with state: active=%v, temperature_state=%v", idx, data.Active, data.TemperatureState)
 
     if idx >= BatteryCount {
-        b.log.Printf("Invalid battery index: %d (num batteries: %d)", idx, BatteryCount)
+        b.log.Error("Invalid battery index: %d (num batteries: %d)", idx, BatteryCount)
         return
     }
 
@@ -52,19 +52,19 @@ func (b *Battery) GetActiveTemperatureState() BatteryTemperatureState {
     b.mu.RLock()
     defer b.mu.RUnlock()
 
-    b.log.Printf("DETAILED: GetActiveTemperatureState called")
-    b.log.Printf("DETAILED: Battery 0 state: active=%v, temperature_state=%v", b.batteryData[0].Active, b.batteryData[0].TemperatureState)
-    b.log.Printf("DETAILED: Battery 1 state: active=%v, temperature_state=%v", b.batteryData[1].Active, b.batteryData[1].TemperatureState)
+    b.log.Debug("GetActiveTemperatureState called")
+    b.log.Debug("Battery 0 state: active=%v, temperature_state=%v", b.batteryData[0].Active, b.batteryData[0].TemperatureState)
+    b.log.Debug("Battery 1 state: active=%v, temperature_state=%v", b.batteryData[1].Active, b.batteryData[1].TemperatureState)
 
     // If battery 0 is active, return its temperature state
     if b.batteryData[0].Active && !b.batteryData[1].Active {
-        b.log.Printf("Battery 0 is active")
+        b.log.Debug("Battery 0 is active")
         return b.batteryData[0].TemperatureState
     }
 
     // If battery 1 is active, return its temperature state
     if b.batteryData[1].Active && !b.batteryData[0].Active {
-        b.log.Printf("Battery 1 is active")
+        b.log.Debug("Battery 1 is active")
         return b.batteryData[1].TemperatureState
     }
 

--- a/battery.go
+++ b/battery.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"sync"
 )
 
@@ -22,12 +21,12 @@ type BatteryState struct {
 }
 
 type Battery struct {
-	log         *log.Logger
+	log         *LeveledLogger
 	batteryData [BatteryCount]BatteryState
 	mu          sync.RWMutex
 }
 
-func NewBattery(logger *log.Logger) *Battery {
+func NewBattery(logger *LeveledLogger) *Battery {
 	return &Battery{
 		log: logger,
 	}

--- a/diag.go
+++ b/diag.go
@@ -53,15 +53,15 @@ func (d *Diag) SetFaultPresence(fault ecu.ECUFault, present bool) {
 
 	config, ok := ecu.GetFaultConfig(fault)
 	if !ok {
-		d.log.Printf("Unknown fault code: %d", fault)
+		d.log.Warn("Unknown fault code: %d", fault)
 		return
 	}
 
 	if present {
-		d.log.Printf("Fault set: code=%d, description=%s", fault, config.Description)
+		d.log.Warn("Fault set: code=%d, description=%s", fault, config.Description)
 		d.reportFaultPresent(fault, config)
 	} else {
-		d.log.Printf("Fault cleared: code=%d, description=%s", fault, config.Description)
+		d.log.Info("Fault cleared: code=%d, description=%s", fault, config.Description)
 		d.reportFaultAbsent(fault)
 	}
 }
@@ -86,10 +86,10 @@ func (d *Diag) SetFaults(faults map[ecu.ECUFault]bool) {
 		}
 
 		if newPresent {
-			d.log.Printf("Fault set: code=%d, description=%s", fault, config.Description)
+			d.log.Warn("Fault set: code=%d, description=%s", fault, config.Description)
 			d.reportFaultPresent(fault, config)
 		} else {
-			d.log.Printf("Fault cleared: code=%d, description=%s", fault, config.Description)
+			d.log.Info("Fault cleared: code=%d, description=%s", fault, config.Description)
 			d.reportFaultAbsent(fault)
 		}
 	}
@@ -113,7 +113,7 @@ func (d *Diag) reportFaultPresent(fault ecu.ECUFault, config ecu.FaultConfig) {
 	pipe.Publish(d.ctx, diagNotificationChannel, "fault")
 
 	if _, err := pipe.Exec(d.ctx); err != nil {
-		d.log.Printf("Failed to report fault present: %v", err)
+		d.log.Error("Failed to report fault present: %v", err)
 	}
 }
 
@@ -134,6 +134,6 @@ func (d *Diag) reportFaultAbsent(fault ecu.ECUFault) {
 	pipe.Publish(d.ctx, diagNotificationChannel, "fault")
 
 	if _, err := pipe.Exec(d.ctx); err != nil {
-		d.log.Printf("Failed to report fault absent: %v", err)
+		d.log.Error("Failed to report fault absent: %v", err)
 	}
 }

--- a/diag.go
+++ b/diag.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"sync"
 
 	"ecu-service/ecu"
@@ -19,14 +18,14 @@ const (
 )
 
 type Diag struct {
-	log          *log.Logger
+	log          *LeveledLogger
 	redis        *redis.Client
 	mu           sync.RWMutex
 	faultStates  map[ecu.ECUFault]bool
 	ctx          context.Context
 }
 
-func NewDiag(logger *log.Logger, redis *redis.Client) *Diag {
+func NewDiag(logger *LeveledLogger, redis *redis.Client) *Diag {
 	return &Diag{
 		log:         logger,
 		redis:       redis,

--- a/ecu/bosch.go
+++ b/ecu/bosch.go
@@ -195,24 +195,6 @@ func (b *BoschECU) SetKersEnabled(enabled bool) error {
 	return nil
 }
 
-func (b *BoschECU) SendStatusRequest() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	b.logger.Info("Sending status request (0x4EF) to ECU")
-
-	frame := can.Frame{
-		ID:     BoschStatusRequestFrameID,
-		Length: 1,
-		Data:   [8]byte{0x01}, // report_all_ecu_settings = 1
-	}
-
-	// Log outgoing CAN frame
-	DebugCANFrame(b.logger, "TX", frame.ID, frame.Data, frame.Length)
-
-	return b.bus.Publish(frame)
-}
-
 // Implement getters
 func (b *BoschECU) GetSpeed() uint16 {
 	b.mu.RLock()

--- a/ecu/bosch.go
+++ b/ecu/bosch.go
@@ -195,6 +195,24 @@ func (b *BoschECU) SetKersEnabled(enabled bool) error {
 	return nil
 }
 
+func (b *BoschECU) SendStatusRequest() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.logger.Info("Sending status request (0x4EF) to ECU")
+
+	frame := can.Frame{
+		ID:     BoschStatusRequestFrameID,
+		Length: 1,
+		Data:   [8]byte{0x01}, // report_all_ecu_settings = 1
+	}
+
+	// Log outgoing CAN frame
+	DebugCANFrame(b.logger, "TX", frame.ID, frame.Data, frame.Length)
+
+	return b.bus.Publish(frame)
+}
+
 // Implement getters
 func (b *BoschECU) GetSpeed() uint16 {
 	b.mu.RLock()

--- a/ecu/interface.go
+++ b/ecu/interface.go
@@ -33,6 +33,9 @@ type ECUInterface interface {
 	// SetKersEnabled enables/disables KERS functionality
 	SetKersEnabled(enabled bool) error
 
+	// SendStatusRequest sends a status request (0x4EF) to trigger ECU to send all status messages
+	SendStatusRequest() error
+
 	// GetSpeed returns the current speed in km/h
 	GetSpeed() uint16
 

--- a/ecu/interface.go
+++ b/ecu/interface.go
@@ -2,7 +2,6 @@ package ecu
 
 import (
 	"context"
-	"log"
 
 	"github.com/brutella/can"
 )
@@ -17,7 +16,7 @@ const (
 
 // ECUConfig contains configuration for the ECU
 type ECUConfig struct {
-	Logger    *log.Logger
+	Logger    Logger
 	CANDevice string
 	CANBus    *can.Bus
 	ECUType   ECUType
@@ -67,6 +66,9 @@ type ECUInterface interface {
 	// GetKersEnabled returns whether KERS is enabled
 	GetKersEnabled() bool
 
+	// IsDataStale returns true if no data has been received recently
+	IsDataStale() bool
+
 	// Cleanup performs any necessary cleanup
 	Cleanup()
 }
@@ -74,13 +76,10 @@ type ECUInterface interface {
 func NewECU(ecuType ECUType) ECUInterface {
 	switch ecuType {
 	case ECUTypeBosch:
-		log.Printf("Creating Bosch ECU")
 		return NewBoschECU()
 	case ECUTypeVotol:
-		log.Printf("Creating Votol ECU")
 		return NewVotolECU()
 	default:
-		log.Printf("Unknown ECU type: %v", ecuType)
 		return nil
 	}
 }

--- a/ecu/interface.go
+++ b/ecu/interface.go
@@ -33,9 +33,6 @@ type ECUInterface interface {
 	// SetKersEnabled enables/disables KERS functionality
 	SetKersEnabled(enabled bool) error
 
-	// SendStatusRequest sends a status request (0x4EF) to trigger ECU to send all status messages
-	SendStatusRequest() error
-
 	// GetSpeed returns the current speed in km/h
 	GetSpeed() uint16
 

--- a/ecu/logger.go
+++ b/ecu/logger.go
@@ -1,0 +1,60 @@
+package ecu
+
+// Logger interface for ECU logging
+type Logger interface {
+	Printf(format string, v ...interface{})
+	Debug(format string, v ...interface{})
+	Info(format string, v ...interface{})
+	Warn(format string, v ...interface{})
+	Error(format string, v ...interface{})
+	DebugCAN(direction string, id uint32, data []byte, length uint8)
+}
+
+// StdLogger wraps a standard logger to implement the Logger interface
+type StdLogger struct {
+	logger interface {
+		Printf(format string, v ...interface{})
+	}
+}
+
+func NewStdLogger(logger interface{ Printf(format string, v ...interface{}) }) *StdLogger {
+	return &StdLogger{logger: logger}
+}
+
+func (l *StdLogger) Printf(format string, v ...interface{}) {
+	l.logger.Printf(format, v...)
+}
+
+func (l *StdLogger) Debug(format string, v ...interface{}) {
+	// No-op for standard logger
+}
+
+func (l *StdLogger) Info(format string, v ...interface{}) {
+	l.logger.Printf(format, v...)
+}
+
+func (l *StdLogger) Warn(format string, v ...interface{}) {
+	l.logger.Printf(format, v...)
+}
+
+func (l *StdLogger) Error(format string, v ...interface{}) {
+	l.logger.Printf(format, v...)
+}
+
+func (l *StdLogger) DebugCAN(direction string, id uint32, data []byte, length uint8) {
+	// No-op for standard logger
+}
+
+// LogCAN logs CAN frame if logger supports DebugCAN
+func LogCAN(logger Logger, direction string, id uint32, data []byte, length uint8) {
+	if logger != nil {
+		logger.DebugCAN(direction, id, data, length)
+	}
+}
+
+// DebugCANFrame formats and logs a CAN frame
+func DebugCANFrame(logger Logger, direction string, id uint32, data [8]byte, length uint8) {
+	if logger != nil {
+		logger.DebugCAN(direction, id, data[:], length)
+	}
+}

--- a/ecu/votol.go
+++ b/ecu/votol.go
@@ -3,7 +3,6 @@ package ecu
 import (
 	"context"
 	"encoding/binary"
-	"log"
 	"sync"
 
 	"github.com/brutella/can"
@@ -24,7 +23,7 @@ const (
 
 type VotolECU struct {
 	mu     sync.RWMutex
-	logger *log.Logger
+	logger Logger
 	bus    *can.Bus
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -56,7 +55,7 @@ func (v *VotolECU) Initialize(ctx context.Context, config ECUConfig) error {
 	// Create cancellable context
 	v.ctx, v.cancel = context.WithCancel(ctx)
 
-	v.logger.Printf("Initialized Votol ECU")
+	v.logger.Info("Initialized Votol ECU")
 	return nil
 }
 
@@ -230,4 +229,10 @@ func (v *VotolECU) GetRawSpeed() uint16 {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	return v.rawSpeed
+}
+
+// IsDataStale returns false for Votol (stale data detection not implemented yet)
+func (v *VotolECU) IsDataStale() bool {
+	// TODO: Implement stale data detection for Votol ECU
+	return false
 }

--- a/ecu/votol.go
+++ b/ecu/votol.go
@@ -218,6 +218,12 @@ func (v *VotolECU) SetKersEnabled(enabled bool) error {
 	return nil
 }
 
+func (v *VotolECU) SendStatusRequest() error {
+	// Votol ECU does not support status request command
+	// Status messages are sent automatically
+	return nil
+}
+
 func (v *VotolECU) Cleanup() {
 	if v.cancel != nil {
 		v.cancel()

--- a/ecu/votol.go
+++ b/ecu/votol.go
@@ -218,12 +218,6 @@ func (v *VotolECU) SetKersEnabled(enabled bool) error {
 	return nil
 }
 
-func (v *VotolECU) SendStatusRequest() error {
-	// Votol ECU does not support status request command
-	// Status messages are sent automatically
-	return nil
-}
-
 func (v *VotolECU) Cleanup() {
 	if v.cancel != nil {
 		v.cancel()

--- a/engine_app.go
+++ b/engine_app.go
@@ -160,10 +160,6 @@ func NewEngineApp(opts *Options) (*EngineApp, error) {
 		return app.ecu.SetKersEnabled(enabled)
 	})
 
-	app.kers.SetStatusRequestCallback(func() error {
-		return app.ecu.SendStatusRequest()
-	})
-
 	// Create frame handler for CAN messages
 	handler := &frameHandler{app: app}
 	bus.Subscribe(handler)

--- a/engine_app.go
+++ b/engine_app.go
@@ -63,22 +63,22 @@ func (app *EngineApp) writeDefaultRedisState() {
 
 	// Write all default values to Redis
 	if err := app.ipcTx.SendStatus1(status1); err != nil {
-		app.log.Printf("Failed to send default Status1: %v", err)
+		app.log.Error("Failed to send default Status1: %v", err)
 	}
 
 	if err := app.ipcTx.SendStatus2(status2); err != nil {
-		app.log.Printf("Failed to send default Status2: %v", err)
+		app.log.Error("Failed to send default Status2: %v", err)
 	}
 
 	if err := app.ipcTx.SendStatus3(status3); err != nil {
-		app.log.Printf("Failed to send default Status3: %v", err)
+		app.log.Error("Failed to send default Status3: %v", err)
 	}
 
 	if err := app.ipcTx.SendStatus4(status4); err != nil {
-		app.log.Printf("Failed to send default Status4: %v", err)
+		app.log.Error("Failed to send default Status4: %v", err)
 	}
 
-	app.log.Printf("Default Redis state written")
+	app.log.Debug("Default Redis state written")
 }
 
 func NewEngineApp(opts *Options) (*EngineApp, error) {
@@ -104,33 +104,33 @@ func NewEngineApp(opts *Options) (*EngineApp, error) {
 	connectCtx, connectCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer connectCancel()
 
-	app.log.Printf("Connecting to Redis at %s:%d...", opts.RedisServerAddr, opts.RedisServerPort)
+	app.log.Info("Connecting to Redis at %s:%d...", opts.RedisServerAddr, opts.RedisServerPort)
 
 	if err := app.redis.Ping(connectCtx).Err(); err != nil {
-		app.log.Printf("Failed to connect to Redis: %v", err)
+		app.log.Error("Failed to connect to Redis: %v", err)
 		return nil, fmt.Errorf("failed to connect to Redis: %v", err)
 	}
-	app.log.Printf("Successfully connected to Redis")
+	app.log.Info("Connected to Redis")
 
 	// Initialize components
 	app.battery = NewBattery(app.log)
-	app.log.Printf("Battery component initialized")
+	app.log.Debug("Battery component initialized")
 
 	app.ipcTx = NewIPCTx(app.log, app.redis)
-	app.log.Printf("IPC TX component initialized")
+	app.log.Debug("IPC TX component initialized")
 
 	// Write default values to Redis after ipcTx is initialized
 	app.writeDefaultRedisState()
 
 	// Start health check goroutines
 	go app.redisHealthCheck()
-	go app.ecuStaleDataCheck()
+	// Note: ecuStaleDataCheck removed - ECU pauses CAN during flash writes which triggered false positives
 
 	app.kers = NewKERS(app.log, ctx, app.ipcTx)
-	app.log.Printf("KERS component initialized")
+	app.log.Debug("KERS component initialized")
 
 	app.diag = NewDiag(app.log, app.redis)
-	app.log.Printf("Diagnostics component initialized")
+	app.log.Debug("Diagnostics component initialized")
 
 	// Initialize CAN bus
 	bus, err := can.NewBusForInterfaceWithName(opts.CANDevice)
@@ -154,10 +154,14 @@ func NewEngineApp(opts *Options) (*EngineApp, error) {
 	if err := app.ecu.Initialize(ctx, ecuConfig); err != nil {
 		return nil, fmt.Errorf("failed to initialize ECU: %v", err)
 	}
-	app.log.Printf("ECU component initialized - selected ECU type: %v", opts.ECUType)
+	app.log.Info("ECU initialized: %v", opts.ECUType)
 
 	app.kers.SetKersEnabledCallback(func(enabled bool) error {
 		return app.ecu.SetKersEnabled(enabled)
+	})
+
+	app.kers.SetStatusRequestCallback(func() error {
+		return app.ecu.SendStatusRequest()
 	})
 
 	// Create frame handler for CAN messages
@@ -167,7 +171,7 @@ func NewEngineApp(opts *Options) (*EngineApp, error) {
 	// Start CAN message publishing
 	go func() {
 		if err := bus.ConnectAndPublish(); err != nil {
-			app.log.Printf("CAN bus publish error: %v", err)
+			app.log.Error("CAN bus publish error: %v", err)
 		}
 	}()
 
@@ -175,7 +179,7 @@ func NewEngineApp(opts *Options) (*EngineApp, error) {
 	if app.ipcRx == nil {
 		return nil, fmt.Errorf("failed to initialize IPC RX")
 	}
-	app.log.Printf("IPC RX component initialized")
+	app.log.Debug("IPC RX component initialized")
 
 	return app, nil
 }
@@ -219,7 +223,7 @@ func (app *EngineApp) updateRedisState() {
 		}
 
 		if err := app.ipcTx.SendStatus1(status1); err != nil {
-			app.log.Printf("Failed to send Status1: %v", err)
+			app.log.Error("Failed to send Status1: %v", err)
 		} else {
 			app.lastSpeed = currentSpeed
 		}
@@ -239,15 +243,15 @@ func (app *EngineApp) updateRedisState() {
 	}
 
 	if err := app.ipcTx.SendStatus2(status2); err != nil {
-		app.log.Printf("Failed to send Status2: %v", err)
+		app.log.Error("Failed to send Status2: %v", err)
 	}
 
 	if err := app.ipcTx.SendStatus3(status3); err != nil {
-		app.log.Printf("Failed to send Status3: %v", err)
+		app.log.Error("Failed to send Status3: %v", err)
 	}
 
 	if err := app.ipcTx.SendStatus4(status4); err != nil {
-		app.log.Printf("Failed to send Status4: %v", err)
+		app.log.Error("Failed to send Status4: %v", err)
 	}
 
 	activeFaults := app.ecu.GetActiveFaults()
@@ -265,53 +269,19 @@ func (app *EngineApp) redisHealthCheck() {
 		case <-ticker.C:
 			ctx, cancel := context.WithTimeout(app.ctx, 2*time.Second)
 			if err := app.redis.Ping(ctx).Err(); err != nil {
-				app.log.Printf("Redis health check failed: %v", err)
+				app.log.Warn("Redis health check failed: %v", err)
 			}
 			cancel()
 		}
 	}
 }
 
-func (app *EngineApp) ecuStaleDataCheck() {
-	// Check every 500ms for stale ECU data
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-app.ctx.Done():
-			return
-		case <-ticker.C:
-			if app.ecu.IsDataStale() {
-				app.mu.Lock()
-				// Reset speed to 0 when data is stale
-				if app.lastSpeed != 0 {
-					app.log.Printf("ECU data stale, resetting speed to 0")
-					status1 := RedisStatus1{
-						MotorVoltage: 0,
-						MotorCurrent: 0,
-						RPM:          0,
-						Speed:        0,
-						RawSpeed:     0,
-						ThrottleOn:   false,
-					}
-					if err := app.ipcTx.SendStatus1(status1); err != nil {
-						app.log.Printf("Failed to send stale status: %v", err)
-					} else {
-						app.lastSpeed = 0
-					}
-				}
-				app.mu.Unlock()
-			}
-		}
-	}
-}
 
 func (app *EngineApp) Destroy() {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
-	app.log.Printf("Shutting down engine application...")
+	app.log.Info("Shutting down...")
 
 	if app.cancel != nil {
 		app.cancel()
@@ -319,41 +289,33 @@ func (app *EngineApp) Destroy() {
 
 	if app.ipcRx != nil {
 		app.ipcRx.Destroy()
-		app.log.Printf("IPC RX shutdown complete")
 	}
 
 	if app.kers != nil {
 		app.kers.Destroy()
-		app.log.Printf("KERS shutdown complete")
 	}
 
 	if app.battery != nil {
 		app.battery.Destroy()
-		app.log.Printf("Battery shutdown complete")
 	}
 
 	if app.ecu != nil {
 		app.ecu.Cleanup()
-		app.log.Printf("ECU shutdown complete")
 	}
 
 	if app.diag != nil {
 		app.diag.Destroy()
-		app.log.Printf("Diagnostics shutdown complete")
 	}
 
 	if app.ipcTx != nil {
 		app.ipcTx.Destroy()
-		app.log.Printf("IPC TX shutdown complete")
 	}
 
 	if app.redis != nil {
 		if err := app.redis.Close(); err != nil {
-			app.log.Printf("Error closing Redis connection: %v", err)
-		} else {
-			app.log.Printf("Redis connection closed")
+			app.log.Error("Error closing Redis: %v", err)
 		}
 	}
 
-	app.log.Printf("Engine application shutdown complete")
+	app.log.Info("Shutdown complete")
 }

--- a/ipc_rx.go
+++ b/ipc_rx.go
@@ -37,7 +37,7 @@ func NewIPCRx(logger *LeveledLogger, redis *redis.Client, battery *Battery, kers
 
 	// Setup initial subscriptions
 	if err := rx.setupSubscriptions(); err != nil {
-		rx.log.Printf("Failed to setup subscriptions: %v", err)
+		rx.log.Error("Failed to setup subscriptions: %v", err)
 		rx.Destroy()
 		return nil
 	}
@@ -68,7 +68,7 @@ func (rx *IPCRx) setupSubscriptions() error {
 }
 
 func (rx *IPCRx) handleVehicleSubscription() {
-	rx.log.Printf("Starting vehicle subscription handler")
+	rx.log.Info("Starting vehicle subscription handler")
 
 	for {
 		msg, err := rx.vehicleSubscription.Receive(rx.ctx)
@@ -78,21 +78,21 @@ func (rx *IPCRx) handleVehicleSubscription() {
 			}
 			// Check for closed client - panic to trigger systemd restart
 			if err.Error() == "redis: client is closed" {
-				rx.log.Printf("Redis connection lost on vehicle subscription - restarting service")
+				rx.log.Error("Redis connection lost on vehicle subscription - restarting service")
 				panic("Redis disconnected")
 			}
-			rx.log.Printf("Vehicle subscription error: %v", err)
+			rx.log.Error("Vehicle subscription error: %v", err)
 			continue
 		}
 
 		switch m := msg.(type) {
 		case *redis.Message:
-			rx.log.Printf("Vehicle message received: channel=%s, payload=%s", m.Channel, m.Payload)
+			rx.log.Debug("Vehicle message received: channel=%s, payload=%s", m.Channel, m.Payload)
 
 			// Check if state was updated
 			state, err := rx.redis.HGet(rx.ctx, "vehicle", "state").Result()
 			if err != nil && err != redis.Nil {
-				rx.log.Printf("Failed to get vehicle state: %v", err)
+				rx.log.Error("Failed to get vehicle state: %v", err)
 				continue
 			}
 
@@ -101,13 +101,13 @@ func (rx *IPCRx) handleVehicleSubscription() {
 			}
 
 		case *redis.Subscription:
-			rx.log.Printf("Vehicle subscription event: %s %s", m.Channel, m.Kind)
+			rx.log.Debug("Vehicle subscription event: %s %s", m.Channel, m.Kind)
 		}
 	}
 }
 
 func (rx *IPCRx) handleBatterySubscription(idx int) {
-	rx.log.Printf("Starting battery %d subscription handler", idx)
+	rx.log.Info("Starting battery %d subscription handler", idx)
 
 	for {
 		msg, err := rx.batterySubscriptions[idx].Receive(rx.ctx)
@@ -117,16 +117,16 @@ func (rx *IPCRx) handleBatterySubscription(idx int) {
 			}
 			// Check for closed client - panic to trigger systemd restart
 			if err.Error() == "redis: client is closed" {
-				rx.log.Printf("Redis connection lost on battery %d subscription - restarting service", idx)
+				rx.log.Error("Redis connection lost on battery %d subscription - restarting service", idx)
 				panic("Redis disconnected")
 			}
-			rx.log.Printf("Battery %d subscription error: %v", idx, err)
+			rx.log.Error("Battery %d subscription error: %v", idx, err)
 			continue
 		}
 
 		switch m := msg.(type) {
 		case *redis.Message:
-			rx.log.Printf("Battery %d message received: channel=%s, payload=%s", idx, m.Channel, m.Payload)
+			rx.log.Debug("Battery %d message received: channel=%s, payload=%s", idx, m.Channel, m.Payload)
 
 			batteryKey := fmt.Sprintf("battery:%d", idx)
 			state := BatteryState{}
@@ -134,7 +134,7 @@ func (rx *IPCRx) handleBatterySubscription(idx int) {
 			// Get current state first
 			currentState, err := rx.redis.HGetAll(rx.ctx, batteryKey).Result()
 			if err != nil && err != redis.Nil {
-				rx.log.Printf("Failed to get battery %d current state: %v", idx, err)
+				rx.log.Error("Failed to get battery %d current state: %v", idx, err)
 				continue
 			}
 
@@ -162,7 +162,7 @@ func (rx *IPCRx) handleBatterySubscription(idx int) {
 			rx.kers.UpdateBattery(rx.battery.GetActiveTemperatureState())
 
 		case *redis.Subscription:
-			rx.log.Printf("Battery subscription event: %s %s", m.Channel, m.Kind)
+			rx.log.Debug("Battery subscription event: %s %s", m.Channel, m.Kind)
 		}
 	}
 }
@@ -171,9 +171,9 @@ func (rx *IPCRx) readInitialStates() {
 	// Read vehicle state
 	state, err := rx.redis.HGet(rx.ctx, "vehicle", "state").Result()
 	if err != nil && err != redis.Nil {
-		rx.log.Printf("Failed to read initial vehicle state: %v", err)
+		rx.log.Error("Failed to read initial vehicle state: %v", err)
 	} else {
-		rx.log.Printf("Initial vehicle state: %s", state)
+		rx.log.Info("Initial vehicle state: %s", state)
 		rx.handleVehicleState(state)
 	}
 
@@ -184,17 +184,17 @@ func (rx *IPCRx) readInitialStates() {
 
 		state, err := rx.redis.HGet(rx.ctx, batteryKey, "state").Result()
 		if err != nil && err != redis.Nil {
-			rx.log.Printf("Failed to read initial battery %d state: %v", i, err)
+			rx.log.Error("Failed to read initial battery %d state: %v", i, err)
 		} else {
-			rx.log.Printf("Initial battery %d state: %s", i, state)
+			rx.log.Info("Initial battery %d state: %s", i, state)
 			batteryState.Active = (state == "active")
 		}
 
 		tempState, err := rx.redis.HGet(rx.ctx, batteryKey, "temperature-state").Result()
 		if err != nil && err != redis.Nil {
-			rx.log.Printf("Failed to read initial battery %d temperature state: %v", i, err)
+			rx.log.Error("Failed to read initial battery %d temperature state: %v", i, err)
 		} else {
-			rx.log.Printf("Initial battery %d temperature state: %s", i, tempState)
+			rx.log.Info("Initial battery %d temperature state: %s", i, tempState)
 			switch tempState {
 			case "cold":
 				batteryState.TemperatureState = BatteryTemperatureStateCold
@@ -219,11 +219,15 @@ func (rx *IPCRx) handleVehicleState(state string) {
 	var vehicleState VehicleState
 	if state == "ready-to-drive" {
 		vehicleState = VehicleStateEngineReady
-		rx.log.Printf("Vehicle state changed to: ready-to-drive")
+		rx.log.Info("Vehicle state changed to: ready-to-drive")
 	} else {
 		vehicleState = VehicleStateEngineNotReady
-		rx.log.Printf("Vehicle state changed to: %s", state)
+		rx.log.Info("Vehicle state changed to: %s", state)
 	}
+
+	// ECU is enabled in parked and ready-to-drive states
+	ecuEnabled := state == "parked" || state == "ready-to-drive"
+	rx.kers.HandleECUEnabled(ecuEnabled)
 
 	rx.kers.HandleVehicleStateChange(vehicleState)
 }

--- a/ipc_rx.go
+++ b/ipc_rx.go
@@ -225,10 +225,6 @@ func (rx *IPCRx) handleVehicleState(state string) {
 		rx.log.Info("Vehicle state changed to: %s", state)
 	}
 
-	// ECU is enabled in parked and ready-to-drive states
-	ecuEnabled := state == "parked" || state == "ready-to-drive"
-	rx.kers.HandleECUEnabled(ecuEnabled)
-
 	rx.kers.HandleVehicleStateChange(vehicleState)
 }
 

--- a/ipc_rx.go
+++ b/ipc_rx.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 
 	"github.com/go-redis/redis/v8"
@@ -12,7 +11,7 @@ import (
 const IpcRxBatteryNameSize = 16
 
 type IPCRx struct {
-	log     *log.Logger
+	log     *LeveledLogger
 	redis   *redis.Client
 	battery *Battery
 	kers    *KERS
@@ -24,7 +23,7 @@ type IPCRx struct {
 	vehicleSubscription  *redis.PubSub
 }
 
-func NewIPCRx(logger *log.Logger, redis *redis.Client, battery *Battery, kers *KERS) *IPCRx {
+func NewIPCRx(logger *LeveledLogger, redis *redis.Client, battery *Battery, kers *KERS) *IPCRx {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	rx := &IPCRx{

--- a/ipc_tx.go
+++ b/ipc_tx.go
@@ -3,20 +3,19 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 
 	"github.com/go-redis/redis/v8"
 )
 
 type IPCTx struct {
-	log   *log.Logger
+	log   *LeveledLogger
 	redis *redis.Client
 	mu    sync.Mutex
 	ctx   context.Context
 }
 
-func NewIPCTx(logger *log.Logger, redis *redis.Client) *IPCTx {
+func NewIPCTx(logger *LeveledLogger, redis *redis.Client) *IPCTx {
 	return &IPCTx{
 		log:   logger,
 		redis: redis,

--- a/kers.go
+++ b/kers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 )
@@ -25,7 +24,7 @@ const (
 )
 
 type KERS struct {
-	log              *log.Logger
+	log              *LeveledLogger
 	ipcTx            *IPCTx
 	kersCallback     func(bool) error
 	temperatureState BatteryTemperatureState
@@ -37,7 +36,7 @@ type KERS struct {
 	ctx              context.Context
 }
 
-func NewKERS(logger *log.Logger, ctx context.Context, ipcTx *IPCTx) *KERS {
+func NewKERS(logger *LeveledLogger, ctx context.Context, ipcTx *IPCTx) *KERS {
 	k := &KERS{
 		log:              logger,
 		ctx:              ctx,

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"log"
+)
+
+// LeveledLogger wraps a standard logger with log level filtering
+type LeveledLogger struct {
+	logger   *log.Logger
+	logLevel LogLevel
+}
+
+// NewLeveledLogger creates a new leveled logger
+func NewLeveledLogger(logger *log.Logger, level LogLevel) *LeveledLogger {
+	return &LeveledLogger{
+		logger:   logger,
+		logLevel: level,
+	}
+}
+
+// Debug logs a message at DEBUG level
+func (l *LeveledLogger) Debug(format string, v ...interface{}) {
+	if l.logLevel >= LogLevelDebug {
+		l.logger.Printf("[DEBUG] "+format, v...)
+	}
+}
+
+// Info logs a message at INFO level
+func (l *LeveledLogger) Info(format string, v ...interface{}) {
+	if l.logLevel >= LogLevelInfo {
+		l.logger.Printf("[INFO] "+format, v...)
+	}
+}
+
+// Warn logs a message at WARN level
+func (l *LeveledLogger) Warn(format string, v ...interface{}) {
+	if l.logLevel >= LogLevelWarn {
+		l.logger.Printf("[WARN] "+format, v...)
+	}
+}
+
+// Error logs a message at ERROR level
+func (l *LeveledLogger) Error(format string, v ...interface{}) {
+	if l.logLevel >= LogLevelError {
+		l.logger.Printf("[ERROR] "+format, v...)
+	}
+}
+
+// Printf provides compatibility with standard logger - logs at INFO level
+func (l *LeveledLogger) Printf(format string, v ...interface{}) {
+	l.Info(format, v...)
+}
+
+// Fatalf logs a fatal error and exits
+func (l *LeveledLogger) Fatalf(format string, v ...interface{}) {
+	l.logger.Fatalf("[FATAL] "+format, v...)
+}
+
+// SetLevel changes the log level
+func (l *LeveledLogger) SetLevel(level LogLevel) {
+	l.logLevel = level
+}
+
+// GetLevel returns the current log level
+func (l *LeveledLogger) GetLevel() LogLevel {
+	return l.logLevel
+}
+
+// DebugCAN logs CAN frame details at DEBUG level with formatting
+func (l *LeveledLogger) DebugCAN(direction string, id uint32, data []byte, length uint8) {
+	if l.logLevel >= LogLevelDebug {
+		dataStr := ""
+		for i := uint8(0); i < length && i < 8; i++ {
+			dataStr += fmt.Sprintf("%02X ", data[i])
+		}
+		l.logger.Printf("[DEBUG] CAN %s: ID=0x%03X Len=%d Data=[%s]", direction, id, length, dataStr)
+	}
+}
+
+// Ensure LeveledLogger implements ecu.Logger interface at compile time
+var _ interface {
+	Printf(format string, v ...interface{})
+	Debug(format string, v ...interface{})
+	Info(format string, v ...interface{})
+	Warn(format string, v ...interface{})
+	Error(format string, v ...interface{})
+	DebugCAN(direction string, id uint32, data []byte, length uint8)
+} = (*LeveledLogger)(nil)

--- a/main.go
+++ b/main.go
@@ -52,23 +52,26 @@ func main() {
 		log.Fatalf("invalid log level %d", *logLevel)
 	}
 
-	// Create logger - remove timestamp/prefix when running under systemd
-	var logger *log.Logger
+	// Create base logger - remove timestamp/prefix when running under systemd
+	var baseLogger *log.Logger
 	if os.Getenv("INVOCATION_ID") != "" {
-		logger = log.New(os.Stdout, "", 0)
+		baseLogger = log.New(os.Stdout, "", 0)
 	} else {
-		logger = log.New(os.Stdout, "", log.LstdFlags)
+		baseLogger = log.New(os.Stdout, "", log.LstdFlags)
 	}
+
+	// Create leveled logger wrapper
+	logger := NewLeveledLogger(baseLogger, LogLevel(*logLevel))
 
 	// Parse ECU type
 	var ecuTypeEnum ecu.ECUType
 	switch *ecuType {
 	case "bosch":
 		ecuTypeEnum = ecu.ECUTypeBosch
-		logger.Printf("Selected ECU type: Bosch")
+		logger.Info("Selected ECU type: Bosch")
 	case "votol":
 		ecuTypeEnum = ecu.ECUTypeVotol
-		logger.Printf("Selected ECU type: Votol")
+		logger.Info("Selected ECU type: Votol")
 	default:
 		logger.Fatalf("invalid ECU type: %s (must be 'bosch' or 'votol')", *ecuType)
 	}

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package main
 
 import (
     "ecu-service/ecu"
-    "log"
 )
 
 type LogLevel int
@@ -21,5 +20,5 @@ type Options struct {
     RedisServerPort  uint16
     CANDevice        string
     ECUType          ecu.ECUType
-    Logger           *log.Logger
+    Logger           *LeveledLogger
 }


### PR DESCRIPTION
## Summary

- Add leveled logger with configurable log levels (NONE/ERROR/WARN/INFO/DEBUG)
- Standardize logging throughout codebase with appropriate log levels
- Remove ECU stale data check that caused false positives during flash writes
- Add CAN frame debug output at DEBUG level

## Changes

### Leveled Logging System
- New `LeveledLogger` with log levels 0-4 (NONE to DEBUG)
- `-log` CLI flag to control verbosity
- CAN frame debug logging for TX/RX frames
- Consistent log level usage:
  - ERROR: Failures and errors
  - WARN: Warnings and fault conditions
  - INFO: State changes and important events
  - DEBUG: Detailed diagnostic information

### Bug Fixes
- Remove `ecuStaleDataCheck()` that incorrectly reset speed to 0 during ECU flash writes
- ECU pauses CAN during flash operations, which isn't a true fault condition

### Commits
1. Add leveled logger with CAN frame debug output
2. Standardize log levels in battery and diag components
3. Add status request command to ECU interface
4. Add ECU power state tracking and automatic status requests
5. Remove status request feature (ineffective due to E15 fault in parked state)

## Testing
- Deployed and tested on deep-blue
- Verified INFO level logging works correctly
- Confirmed DEBUG level shows CAN frame output
- Service starts and operates normally

## Notes
The status request feature (commits 3-4) was reverted (commit 5) because:
- In "parked" state: ECU enters E15 fault due to brake signal, won't respond
- In "ready-to-drive" state: ECU sends updates automatically, request not needed