### PR TITLE
fix: only raise E20 when ECU reports non-zero speed

### DIFF
--- a/engine_app.go
+++ b/engine_app.go
@@ -594,7 +594,8 @@ func (app *EngineApp) checkCommLost() {
 		}
 	}
 	stale := frameAge > raiseAfter
-	shouldRaise := stale && powerOn && ecuExpectedAlive && !inPowerOnGrace
+	moving := app.ecu.GetSpeed() != 0
+	shouldRaise := stale && powerOn && ecuExpectedAlive && !inPowerOnGrace && moving
 
 	app.mu.Lock()
 	defer app.mu.Unlock()


### PR DESCRIPTION
## Summary
- Gate the E20 raise on `app.ecu.GetSpeed() != 0` so a silent ECU at standstill no longer trips comm-lost.

E20 was firing when the scooter was parked and the ECU went quiet. The fault only matters while moving, where losing frames is an actual safety signal.

## Test plan
- [x] Park with ECU on, confirm E20 does not raise after the stale window.
- [ ] Drive, disable battery or otherwise cut comms, confirm E20 raises.
- [ ] Return 48v at standstill, confirm E20 clears.